### PR TITLE
Add VanillaBukkit branding to plugin.yml

### DIFF
--- a/src/main/java/us/donut/visualbukkit/plugin/PluginBuilder.java
+++ b/src/main/java/us/donut/visualbukkit/plugin/PluginBuilder.java
@@ -93,7 +93,7 @@ public class PluginBuilder {
             pluginYml.append("author: ").append(author).append('\n');
         }
         if (!desc.isEmpty()) {
-            pluginYml.append("description: ").append(desc).append('\n');
+            pluginYml.append("description: ").append(desc).append(' | Created with VisualBukkit\n');
         }
         pluginYml.append("api-version: 1.13\n");
         pluginYml.append("commands:\n");


### PR DESCRIPTION
Specifically so people cannot say that they programmed it, even though they didn't. Maybe if it becomes a paid program, then remove this.