### PR TITLE
Switch to "user.home" path for output

### DIFF
--- a/src/main/java/us/donut/visualbukkit/editor/Project.java
+++ b/src/main/java/us/donut/visualbukkit/editor/Project.java
@@ -251,7 +251,7 @@ public class Project {
             pluginVerField.setText(data.getString("plugin.version", ""));
             pluginAuthorField.setText(data.getString("plugin.author", ""));
             pluginDescField.setText(data.getString("plugin.description", ""));
-            pluginOutputDirField.setText(data.getString("plugin.output-dir", System.getProperty("user.dir")));
+            pluginOutputDirField.setText(data.getString("plugin.output-dir", System.getProperty("user.home")));
 
             Button buildButton = new Button("Build Plugin");
             buildButton.setOnAction(e -> {

--- a/src/main/java/us/donut/visualbukkit/editor/Project.java
+++ b/src/main/java/us/donut/visualbukkit/editor/Project.java
@@ -251,7 +251,7 @@ public class Project {
             pluginVerField.setText(data.getString("plugin.version", ""));
             pluginAuthorField.setText(data.getString("plugin.author", ""));
             pluginDescField.setText(data.getString("plugin.description", ""));
-            pluginOutputDirField.setText(data.getString("plugin.output-dir", System.getProperty("user.home")));
+            pluginOutputDirField.setText(data.getString("plugin.output-dir", folder.resolve("output").toString()));
 
             Button buildButton = new Button("Build Plugin");
             buildButton.setOnAction(e -> {

--- a/src/main/java/us/donut/visualbukkit/plugin/PluginBuilder.java
+++ b/src/main/java/us/donut/visualbukkit/plugin/PluginBuilder.java
@@ -64,12 +64,13 @@ public class PluginBuilder {
             blockPane.insertInto(mainClass);
         }
 
-        Path projectDir = project.getPluginOutputDir().resolve(name);
+        Path projectDir = project.getPluginOutputDir();
         Path srcDir = projectDir.resolve("src");
         Path jar = projectDir.resolve(name + ".jar");
         Path pluginYml = srcDir.resolve("plugin.yml");
 
-        if (Files.exists(projectDir)) {
+        Files.deleteIfExists(jar);
+        if (Files.exists(srcDir)) {
             MoreFiles.deleteRecursively(projectDir, RecursiveDeleteOption.ALLOW_INSECURE);
         }
 

--- a/src/main/java/us/donut/visualbukkit/plugin/PluginBuilder.java
+++ b/src/main/java/us/donut/visualbukkit/plugin/PluginBuilder.java
@@ -64,14 +64,14 @@ public class PluginBuilder {
             blockPane.insertInto(mainClass);
         }
 
-        Path projectDir = project.getPluginOutputDir();
-        Path srcDir = projectDir.resolve("src");
-        Path jar = projectDir.resolve(name + ".jar");
+        Path outputDir = project.getPluginOutputDir();
+        Path srcDir = outputDir.resolve("src");
+        Path jar = outputDir.resolve(name + ".jar");
         Path pluginYml = srcDir.resolve("plugin.yml");
 
         Files.deleteIfExists(jar);
         if (Files.exists(srcDir)) {
-            MoreFiles.deleteRecursively(projectDir, RecursiveDeleteOption.ALLOW_INSECURE);
+            MoreFiles.deleteRecursively(srcDir, RecursiveDeleteOption.ALLOW_INSECURE);
         }
 
         Files.createDirectories(srcDir);


### PR DESCRIPTION
The "user.dir" property is the path this application was initialized from. For installations of Java created with the Windows installer, this is typically _C:\Windows\system32\java.exe_ which is not a suitable output directory. Specifically, attempting to save to this location will typically result in the following error:

![output_error](https://user-images.githubusercontent.com/2267126/76184748-73e25e00-61a3-11ea-9a6d-a7d67aa4a0c6.png)

Request solves this by retrieving "user.home" instead, as is already done for the data folder:
https://github.com/OfficialDonut/VisualBukkit/blob/01dfc0c1819254b76fe91b502e8b2f2e42317950/src/main/java/us/donut/visualbukkit/VisualBukkit.java#L35