### PR TITLE
Allow for dynamic parameter sizes

### DIFF
--- a/src/main/java/com/gmail/visualbukkit/blocks/CodeBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/CodeBlock.java
@@ -14,6 +14,8 @@ public interface CodeBlock extends ElementInspector.Inspectable {
 
     String toJava();
 
+    void initParameters(int length);
+
     List<BlockParameter> getParameters();
 
     BlockDefinition<?> getDefinition();
@@ -58,9 +60,10 @@ public interface CodeBlock extends ElementInspector.Inspectable {
     }
 
     default void deserialize(JSONObject obj) {
-        List<BlockParameter> parameters = getParameters();
         JSONArray parameterArray = obj.optJSONArray("parameters");
         if (parameterArray != null) {
+            initParameters(parameterArray.length());
+            List<BlockParameter> parameters = getParameters();
             int len = Math.min(parameters.size(), parameterArray.length());
             for (int i = 0; i < len; i++) {
                 JSONObject parameterObj = parameterArray.optJSONObject(i);

--- a/src/main/java/com/gmail/visualbukkit/blocks/ExpressionBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/ExpressionBlock.java
@@ -185,6 +185,11 @@ public abstract class ExpressionBlock<T> extends CenteredHBox implements CodeBlo
     }
 
     @Override
+    public void initParameters(int length) {
+
+    }
+
+    @Override
     public ExpressionDefinition<?> getDefinition() {
         return BlockRegistry.getExpression(this);
     }

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
@@ -314,6 +314,11 @@ public abstract class StatementBlock extends VBox implements CodeBlock, ElementI
         }
     }
 
+    public void clear(){
+        parameters.clear();
+        syntaxBox.getChildren().clear();
+    }
+
     @Override
     public void delete() {
         UndoManager.capture();
@@ -380,6 +385,11 @@ public abstract class StatementBlock extends VBox implements CodeBlock, ElementI
     @Override
     public List<BlockParameter> getParameters() {
         return parameters;
+    }
+
+    @Override
+    public void initParameters(int length) {
+
     }
 
     @Override


### PR DESCRIPTION
Allow for dynamic parameter sizes.

Example:
[https://github.com/Dablakbandit/VisualBukkit/blob/npc-dialogue/src/main/java/com/gmail/visualbukkit/blocks/statements/StatNpcDialogue.java](https://github.com/Dablakbandit/VisualBukkit/blob/npc-dialogue/src/main/java/com/gmail/visualbukkit/blocks/statements/StatNpcDialogue.java)