### PR TITLE
Add ability for blocks to be dragged based on cursor origin.

### DIFF
--- a/src/main/java/com/gmail/visualbukkit/VisualBukkit.java
+++ b/src/main/java/com/gmail/visualbukkit/VisualBukkit.java
@@ -12,6 +12,7 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.application.Preloader;
 import javafx.geometry.Orientation;
+import javafx.geometry.Point2D;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.control.Menu;
@@ -57,6 +58,7 @@ public class VisualBukkit extends Application {
     private ElementInspector elementInspector;
     private ProjectView projectView;
     private DndTabPane canvasPane;
+    private Point2D lastOffset = new Point2D(0, 0);
 
     public VisualBukkit() {
         if (instance != null) {
@@ -332,5 +334,13 @@ public class VisualBukkit extends Application {
 
     public ProjectView getProjectView() {
         return projectView;
+    }
+
+    public Point2D getLastOffset() {
+        return lastOffset;
+    }
+
+    public void setLastOffset(double x, double y) {
+        this.lastOffset = new Point2D(x, y);
     }
 }

--- a/src/main/java/com/gmail/visualbukkit/VisualBukkit.java
+++ b/src/main/java/com/gmail/visualbukkit/VisualBukkit.java
@@ -12,7 +12,6 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.application.Preloader;
 import javafx.geometry.Orientation;
-import javafx.geometry.Point2D;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.control.Menu;
@@ -334,5 +333,4 @@ public class VisualBukkit extends Application {
     public ProjectView getProjectView() {
         return projectView;
     }
-
 }

--- a/src/main/java/com/gmail/visualbukkit/VisualBukkit.java
+++ b/src/main/java/com/gmail/visualbukkit/VisualBukkit.java
@@ -58,7 +58,6 @@ public class VisualBukkit extends Application {
     private ElementInspector elementInspector;
     private ProjectView projectView;
     private DndTabPane canvasPane;
-    private Point2D lastOffset = new Point2D(0, 0);
 
     public VisualBukkit() {
         if (instance != null) {
@@ -336,11 +335,4 @@ public class VisualBukkit extends Application {
         return projectView;
     }
 
-    public Point2D getLastOffset() {
-        return lastOffset;
-    }
-
-    public void setLastOffset(double x, double y) {
-        this.lastOffset = new Point2D(x, y);
-    }
 }

--- a/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
@@ -10,7 +10,6 @@ import com.gmail.visualbukkit.util.DataFile;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.control.*;
-import javafx.scene.control.MenuItem;
 import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;

--- a/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
@@ -10,6 +10,8 @@ import com.gmail.visualbukkit.util.DataFile;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.control.*;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.TransferMode;
@@ -18,10 +20,13 @@ import javafx.stage.FileChooser;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.awt.*;
 import java.io.File;
 import java.util.List;
 
 public class BlockCanvas extends Pane implements Comparable<BlockCanvas> {
+
+    public static final DataFormat POINT = new DataFormat("geom/Point2D");
 
     private Pane innerPane = new Pane();
     private String name;
@@ -55,7 +60,8 @@ public class BlockCanvas extends Pane implements Comparable<BlockCanvas> {
                 block = (StatementBlock) source;
                 block.disconnect();
                 if (!innerPane.equals(block.getParent())) {
-                    add(block, e.getScreenX(), e.getScreenY());
+                    java.awt.geom.Point2D.Double point = (java.awt.geom.Point2D.Double)e.getDragboard().getContent(POINT);
+                    add(block, e.getScreenX() - point.getX(), e.getScreenY() - point.getY());
                 }
             }
             block.update();
@@ -169,10 +175,7 @@ public class BlockCanvas extends Pane implements Comparable<BlockCanvas> {
     private void add(Node node, double screenX, double screenY) {
         innerPane.getChildren().add(node);
         Point2D point = innerPane.screenToLocal(screenX, screenY);
-        Point2D offset = VisualBukkit.getInstance().getLastOffset();
-        point = point.subtract(offset);
         node.relocate(point.getX(), point.getY());
-        VisualBukkit.getInstance().setLastOffset(0, 0);
     }
 
     public void pan(double deltaX, double deltaY) {

--- a/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
@@ -20,7 +20,6 @@ import javafx.stage.FileChooser;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.awt.*;
 import java.io.File;
 import java.util.List;
 

--- a/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
@@ -59,7 +59,7 @@ public class BlockCanvas extends Pane implements Comparable<BlockCanvas> {
                 block = (StatementBlock) source;
                 block.disconnect();
                 if (!innerPane.equals(block.getParent())) {
-                    java.awt.geom.Point2D.Double point = (java.awt.geom.Point2D.Double)e.getDragboard().getContent(POINT);
+                    java.awt.geom.Point2D.Double point = (java.awt.geom.Point2D.Double) e.getDragboard().getContent(POINT);
                     add(block, e.getScreenX() - point.getX(), e.getScreenY() - point.getY());
                 }
             }

--- a/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/BlockCanvas.java
@@ -169,7 +169,10 @@ public class BlockCanvas extends Pane implements Comparable<BlockCanvas> {
     private void add(Node node, double screenX, double screenY) {
         innerPane.getChildren().add(node);
         Point2D point = innerPane.screenToLocal(screenX, screenY);
+        Point2D offset = VisualBukkit.getInstance().getLastOffset();
+        point = point.subtract(offset);
         node.relocate(point.getX(), point.getY());
+        VisualBukkit.getInstance().setLastOffset(0, 0);
     }
 
     public void pan(double deltaX, double deltaY) {

--- a/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
@@ -1,6 +1,5 @@
 package com.gmail.visualbukkit.blocks;
 
-import com.gmail.visualbukkit.VisualBukkit;
 import com.gmail.visualbukkit.blocks.annotations.BlockColor;
 import com.gmail.visualbukkit.gui.NotificationManager;
 import com.gmail.visualbukkit.gui.UndoManager;
@@ -15,6 +14,9 @@ import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.awt.*;
+import java.awt.geom.Point2D;
 
 @BlockColor("#add8e6ff")
 public abstract class ParentBlock extends StatementBlock {
@@ -40,9 +42,9 @@ public abstract class ParentBlock extends StatementBlock {
                 SnapshotParameters snapshotParameters = new SnapshotParameters();
                 snapshotParameters.setFill(Color.TRANSPARENT);
                 dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
-                VisualBukkit.getInstance().setLastOffset(e.getX(), e.getY());
                 ClipboardContent content = new ClipboardContent();
                 content.putString("");
+                content.put(BlockCanvas.POINT, new Point2D.Double(e.getX(), e.getY()));
                 dragboard.setContent(content);
                 setOpacity(0.5);
                 setAcceptingConnections(false);

--- a/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
@@ -42,7 +42,6 @@ public abstract class ParentBlock extends StatementBlock {
                 snapshotParameters.setFill(Color.TRANSPARENT);
                 dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
                 ClipboardContent content = new ClipboardContent();
-                content.putString("");
                 content.put(BlockCanvas.POINT, new Point2D.Double(e.getX(), e.getY()));
                 dragboard.setContent(content);
                 setOpacity(0.5);

--- a/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
@@ -15,7 +15,6 @@ import javafx.scene.paint.Color;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.awt.*;
 import java.awt.geom.Point2D;
 
 @BlockColor("#add8e6ff")

--- a/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/ParentBlock.java
@@ -1,5 +1,6 @@
 package com.gmail.visualbukkit.blocks;
 
+import com.gmail.visualbukkit.VisualBukkit;
 import com.gmail.visualbukkit.blocks.annotations.BlockColor;
 import com.gmail.visualbukkit.gui.NotificationManager;
 import com.gmail.visualbukkit.gui.UndoManager;
@@ -38,7 +39,8 @@ public abstract class ParentBlock extends StatementBlock {
                 Dragboard dragboard = startDragAndDrop(TransferMode.ANY);
                 SnapshotParameters snapshotParameters = new SnapshotParameters();
                 snapshotParameters.setFill(Color.TRANSPARENT);
-                dragboard.setDragView(snapshot(snapshotParameters, null));
+                dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
+                VisualBukkit.getInstance().setLastOffset(e.getX(), e.getY());
                 ClipboardContent content = new ClipboardContent();
                 content.putString("");
                 dragboard.setContent(content);

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
@@ -82,7 +82,6 @@ public abstract class StatementBlock extends VBox implements CodeBlock, ElementI
                 snapshotParameters.setFill(Color.TRANSPARENT);
                 dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
                 ClipboardContent content = new ClipboardContent();
-                content.putString("");
                 content.put(BlockCanvas.POINT, new Point2D.Double(e.getX(), e.getY()));
                 dragboard.setContent(content);
                 setOpacity(0.5);

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
@@ -27,6 +27,7 @@ import javafx.scene.text.Text;
 import javafx.stage.DirectoryChooser;
 import javafx.util.Duration;
 
+import java.awt.geom.Point2D;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -80,9 +81,9 @@ public abstract class StatementBlock extends VBox implements CodeBlock, ElementI
                 SnapshotParameters snapshotParameters = new SnapshotParameters();
                 snapshotParameters.setFill(Color.TRANSPARENT);
                 dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
-                VisualBukkit.getInstance().setLastOffset(e.getX(), e.getY());
                 ClipboardContent content = new ClipboardContent();
                 content.putString("");
+                content.put(BlockCanvas.POINT, new Point2D.Double(e.getX(), e.getY()));
                 dragboard.setContent(content);
                 setOpacity(0.5);
                 setAcceptingConnections(false);

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementBlock.java
@@ -79,7 +79,8 @@ public abstract class StatementBlock extends VBox implements CodeBlock, ElementI
                 Dragboard dragboard = startDragAndDrop(TransferMode.ANY);
                 SnapshotParameters snapshotParameters = new SnapshotParameters();
                 snapshotParameters.setFill(Color.TRANSPARENT);
-                dragboard.setDragView(snapshot(snapshotParameters, null));
+                dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
+                VisualBukkit.getInstance().setLastOffset(e.getX(), e.getY());
                 ClipboardContent content = new ClipboardContent();
                 content.putString("");
                 dragboard.setContent(content);

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
@@ -30,7 +30,8 @@ public class StatementLabel extends Label implements ElementInspector.Inspectabl
             Dragboard dragboard = startDragAndDrop(TransferMode.ANY);
             SnapshotParameters snapshotParameters = new SnapshotParameters();
             snapshotParameters.setFill(Color.TRANSPARENT);
-            dragboard.setDragView(snapshot(snapshotParameters, null));
+            dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
+            VisualBukkit.getInstance().setLastOffset(e.getX(), e.getY());
             ClipboardContent content = new ClipboardContent();
             content.putString("");
             dragboard.setContent(content);

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
@@ -34,7 +34,6 @@ public class StatementLabel extends Label implements ElementInspector.Inspectabl
             snapshotParameters.setFill(Color.TRANSPARENT);
             dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
             ClipboardContent content = new ClipboardContent();
-            content.putString("");
             content.put(BlockCanvas.POINT, new Point2D.Double(e.getX(), e.getY()));
             dragboard.setContent(content);
             e.consume();

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
@@ -12,7 +12,6 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
-import jdk.nashorn.internal.ir.Block;
 
 import java.awt.geom.Point2D;
 

--- a/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
+++ b/src/main/java/com/gmail/visualbukkit/blocks/StatementLabel.java
@@ -12,6 +12,9 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
+import jdk.nashorn.internal.ir.Block;
+
+import java.awt.geom.Point2D;
 
 public class StatementLabel extends Label implements ElementInspector.Inspectable {
 
@@ -31,9 +34,9 @@ public class StatementLabel extends Label implements ElementInspector.Inspectabl
             SnapshotParameters snapshotParameters = new SnapshotParameters();
             snapshotParameters.setFill(Color.TRANSPARENT);
             dragboard.setDragView(snapshot(snapshotParameters, null), e.getX(), e.getY());
-            VisualBukkit.getInstance().setLastOffset(e.getX(), e.getY());
             ClipboardContent content = new ClipboardContent();
             content.putString("");
+            content.put(BlockCanvas.POINT, new Point2D.Double(e.getX(), e.getY()));
             dragboard.setContent(content);
             e.consume();
         });


### PR DESCRIPTION
Whilst using the interface I found it annoying how the blocks would snap to the cursor when moved.
I resolved this but saving the origin point of the cursor when starting to drag, and then altering the final position.

This possibly isn't the best place for the Point2D to be stored? Feel free to change this around.

I tried getting the offset of the content dragged on the drop event but this seems to reset?